### PR TITLE
Fix bad input bugs -- _Pyra

### DIFF
--- a/generatorClient.js
+++ b/generatorClient.js
@@ -1,6 +1,17 @@
 $(document).ready(function () {
-
+	
 	function getRidingBlock(userCommand){
+		// If user enters bad/empty input, DON'T LET IT BREAK lol
+		if(userCommand === ""){
+			userCommand = "say Missing input.";
+		}
+		var cmdType = typeof userCommand;
+		cmdType = cmdType.toString();
+		if(cmdType !== "string"){
+			// It's not a string! :O
+			userCommand = "say Bad input: " + userCommand;
+		}
+		
 		return ",Riding:{id:FallingSand,Time:1,Block:command_block,TileEntityData:{Command:" + userCommand + "}";
 	}
 


### PR DESCRIPTION
If you put in a number or something that would definitely never work into this website, it would return something that would, also, definitely not work. Here it;s changed so if you put in, say, an empty string, it will replace the command with either "say Missing input." or "say Bad input: <user input here>".
